### PR TITLE
BUG: profile stats not showing top 3

### DIFF
--- a/cv_next/app/profile/[profileId]/components/categoryCounter.tsx
+++ b/cv_next/app/profile/[profileId]/components/categoryCounter.tsx
@@ -6,7 +6,9 @@ import Categories from "@/types/models/categories";
 const getTopCategories = async (cvs: CvModel[]) => {
   const categoryCount: { [key: number]: number } = {};
   cvs.forEach((cv) => {
-    categoryCount[cv.category_id] = (categoryCount[cv.category_id] || 0) + 1;
+    cv.cv_categories.forEach((category_id) => {
+      categoryCount[category_id] = (categoryCount[category_id] || 0) + 1;
+    });
   });
 
   const categoryCountArray = Object.entries(categoryCount).map(


### PR DESCRIPTION
cv was probably refactored and contains both `category_id` and `cv_categories` the new one being `cv_categories`
and so I added a foreach in `getTopCategories` to take in account all of the categories of a certain cv

**we should probably remove `category_id` from the attributes of the cv**
edit: this is already mentioned in #118