### PR TITLE
FIXED: extending the description to needed size vertically

### DIFF
--- a/cv_next/app/feed/components/inputbar.tsx
+++ b/cv_next/app/feed/components/inputbar.tsx
@@ -36,7 +36,7 @@ export const InputTextArea = ({
     <textarea
       name="textArea"
       rows={2}
-      className={`border-gray-40 h-3/6 w-full border-2 bg-white px-10 py-4 text-center md:text-left ${searchColor} max-h-40 rounded-md`}
+      className={`border-gray-40 w-full border-2 bg-white px-10 py-4 text-center md:text-left ${searchColor} resize:vertical rounded-md`}
       onChange={(event) => {
         onChange(event.target.value);
       }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/762d5c59-7ce8-4540-a97e-6e01fd0029b4)

can stretch as much as needed