### PR TITLE
Bug: error hook was broken tailwind was missing provider

### DIFF
--- a/cv_next/app/globals.css
+++ b/cv_next/app/globals.css
@@ -31,7 +31,7 @@
   --secondary-foreground: var(--theme-800);
   --accent: var(--theme-200);
   --accent-foreground: var(--theme-800);
-  --destructive: #da6161;
+  --destructive: #f87171;
   --destructive-foreground: var(--theme-100);
   --ring: var(--theme-600);
 }
@@ -53,7 +53,7 @@
   --secondary-foreground: var(--theme-800);
   --accent: var(--theme-700);
   --accent-foreground: var(--white);
-  --destructive: #da6161;
+  --destructive: #991b1b;
   --destructive-foreground: var(--theme-800);
   --ring: var(--theme-100);
 }

--- a/cv_next/providers/error-provider.tsx
+++ b/cv_next/providers/error-provider.tsx
@@ -43,10 +43,10 @@ export const ErrorProvider = ({ children }: { children: ReactNode }) => {
       {children}
       {errorMsg && (
         <PopupWrapper onClose={clearError}>
-          <div className="flex flex-col items-center justify-center rounded-md border-2 border-black bg-red-700 px-4 py-2 text-red-500">
+          <div className="flex flex-col items-center justify-center rounded-md border-2 border-primary bg-destructive px-4 py-2 text-primary">
             <div className="text-xl font-bold">{errorMsg}</div>
             {errorDescription && (
-              <div className="mt-2 text-lg text-red-500/90">
+              <div className="mt-2 text-lg text-primary">
                 {errorDescription}
               </div>
             )}

--- a/cv_next/providers/error-provider.tsx
+++ b/cv_next/providers/error-provider.tsx
@@ -43,10 +43,10 @@ export const ErrorProvider = ({ children }: { children: ReactNode }) => {
       {children}
       {errorMsg && (
         <PopupWrapper onClose={clearError}>
-          <div className="flex flex-col items-center justify-center rounded-md border-2 border-black bg-red-700 px-4 py-2 text-white">
+          <div className="flex flex-col items-center justify-center rounded-md border-2 border-black bg-red-700 px-4 py-2 text-red-500">
             <div className="text-xl font-bold">{errorMsg}</div>
             {errorDescription && (
-              <div className="mt-2 text-lg text-white/90">
+              <div className="mt-2 text-lg text-red-500/90">
                 {errorDescription}
               </div>
             )}

--- a/cv_next/tailwind.config.js
+++ b/cv_next/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
+    "./providers/**/*.{ts,tsx}",
   ],
   theme: {
     zIndex: {


### PR DESCRIPTION
- [x] fixed error hook color to fit theme
- [x] added  `./providers` to tailwind path
![image](https://github.com/user-attachments/assets/933d7293-57ee-49bc-a1c4-b15c167ce209)

- [x] fixed `distractive` to use tailwind colors and pass `tpgi color contrast test`

more mentioned in #252 

