### PR TITLE
315 feature add user approvals page

### DIFF
--- a/cv_next/app/actions/users/getUser.ts
+++ b/cv_next/app/actions/users/getUser.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import {
+  getAllUsers,
   getUserById,
   getUserByUsername,
   isCurrentFirstLogin,
@@ -88,3 +89,19 @@ export async function signInWithSocialProvider(provider: any, nextURL: string) {
     redirect(data.url);
   }
 }
+
+/**
+ * Returns all users with their permission level.
+ * @return {Promise<Result<Partial<UserWithPerms>[], string>>} A Promise with the result of the operation.
+ */
+export const getAllUsersPerms = async (): Promise<
+  Result<Partial<UserWithPerms>[], string>
+> => {
+  const result = await getAllUsers();
+  if (result.ok) {
+    return result;
+  } else {
+    logErrorWithTrace(result);
+    return Err("Couldn't get all users", result.errors);
+  }
+};

--- a/cv_next/app/actions/users/updateUser.ts
+++ b/cv_next/app/actions/users/updateUser.ts
@@ -8,6 +8,7 @@ import {
   updateUser,
   setFirstLogin,
   updateUserPerms,
+  activateAllUsers,
 } from "@/server/api/users";
 import { Err } from "@/lib/utils";
 import { logErrorWithTrace } from "@/server/base/logger";
@@ -138,6 +139,20 @@ export const updatePerms = async (
   newPerms: string
 ): Promise<Result<void, string>> => {
   const result = await updateUserPerms({ id: userId, user_type: newPerms });
+  if (result.ok) {
+    return result;
+  } else {
+    logErrorWithTrace(result);
+    return Err("Couldn't update perms.", result.errors);
+  }
+};
+
+/**
+ * Activates all users.
+ * @return {Promise<Result<void, string>>} A Promise with the result of the operation.
+ */
+export const activateUsers = async (): Promise<Result<void, string>> => {
+  const result = await activateAllUsers();
   if (result.ok) {
     return result;
   } else {

--- a/cv_next/app/actions/users/updateUser.ts
+++ b/cv_next/app/actions/users/updateUser.ts
@@ -7,6 +7,7 @@ import {
   setDisplayName,
   updateUser,
   setFirstLogin,
+  updateUserPerms,
 } from "@/server/api/users";
 import { Err } from "@/lib/utils";
 import { logErrorWithTrace } from "@/server/base/logger";
@@ -123,5 +124,24 @@ export const setFirstLoginCurrent = async (
   } else {
     logErrorWithTrace(result);
     return Err("First Login: Couldn't update", result.errors);
+  }
+};
+
+/**
+ * Updates the type of a user.
+ * @param {string} userId - The ID of the user to update
+ * @param {string} newPerms - The new perms
+ * @return {Promise<Result<void, string>>} A Promise with the result of the operation.
+ */
+export const updatePerms = async (
+  userId: string,
+  newPerms: string
+): Promise<Result<void, string>> => {
+  const result = await updateUserPerms({ id: userId, user_type: newPerms });
+  if (result.ok) {
+    return result;
+  } else {
+    logErrorWithTrace(result);
+    return Err("Couldn't update perms.", result.errors);
   }
 };

--- a/cv_next/app/admin/components/permsDropDown.tsx
+++ b/cv_next/app/admin/components/permsDropDown.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { useState } from "react";
+import { PermsKeys } from "@/lib/supabase-definitions";
+
+type FormValues = {
+  perms: keyof typeof PermsKeys.user_types_enum;
+};
+
+export const PermsDropDown = ({
+  userId,
+  currentPerms,
+}: {
+  userId: string;
+  currentPerms: string;
+}) => {
+  const [newPerms, setNewPerms] = useState<string>(currentPerms);
+  const { handleSubmit, register } = useForm<FormValues>({ mode: "onChange" });
+
+  const handleOnSubmit: SubmitHandler<FormValues> = async (data) => {
+    setNewPerms(data.perms);
+    console.log(data);
+  };
+
+  return (
+    <form onChange={handleSubmit(handleOnSubmit)}>
+      <div className="flex flex-wrap justify-between text-center">
+        <select
+          id="perms"
+          {...register("perms", { required: "Permission level is required" })}
+          defaultValue={newPerms}
+          className="rounded-full px-3 py-1 text-sm font-medium"
+          style={{
+            backgroundColor:
+              newPerms === "inactive"
+                ? "#EF4444"
+                : newPerms === "admin"
+                  ? "#F59E0B"
+                  : "#10B981",
+          }}
+        >
+          {Object.entries(PermsKeys.user_types_enum).map(([key, value]) => (
+            <option
+              key={key}
+              value={key}
+              className="rounded-full px-3 py-1 text-sm font-medium"
+              style={{
+                backgroundColor:
+                  value === "inactive"
+                    ? "#EF4444"
+                    : value === "admin"
+                      ? "#F59E0B"
+                      : "#10B981",
+              }}
+            >
+              {value}
+            </option>
+          ))}
+        </select>
+      </div>
+    </form>
+  );
+};

--- a/cv_next/app/admin/components/permsDropDown.tsx
+++ b/cv_next/app/admin/components/permsDropDown.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { PermsKeys } from "@/lib/supabase-definitions";
 import { useError } from "@/providers/error-provider";
 import { Visible_Error_Messages } from "@/lib/definitions";
+import { updatePerms } from "@/app/actions/users/updateUser";
 
 type FormValues = {
   perms: keyof typeof PermsKeys.user_types_enum;
@@ -32,7 +33,16 @@ export const PermsDropDown = ({
       return;
     }
     setNewPerms(data.perms);
-    console.log(data);
+    const resp = await updatePerms(userId, data.perms);
+    if (!resp.ok) {
+      showError(
+        "",
+        resp.errors.postgrestError?.message ||
+          resp.errors.authError?.message ||
+          resp.errors.err?.message ||
+          "Unknown error"
+      );
+    }
   };
 
   return (

--- a/cv_next/app/admin/components/permsDropDown.tsx
+++ b/cv_next/app/admin/components/permsDropDown.tsx
@@ -24,7 +24,7 @@ export const PermsDropDown = ({
 
   return (
     <form onChange={handleSubmit(handleOnSubmit)}>
-      <div className="flex flex-wrap justify-between text-center">
+      <div className="flex flex-wrap justify-center text-center">
         <select
           id="perms"
           {...register("perms", { required: "Permission level is required" })}

--- a/cv_next/app/admin/components/permsDropDown.tsx
+++ b/cv_next/app/admin/components/permsDropDown.tsx
@@ -21,7 +21,10 @@ export const PermsDropDown = ({
   const { showError } = useError();
 
   const handleOnSubmit: SubmitHandler<FormValues> = async (data) => {
-    if (currentPerms === PermsKeys.user_types_enum.admin) {
+    if (
+      currentPerms === PermsKeys.user_types_enum.admin ||
+      data.perms === PermsKeys.user_types_enum.admin
+    ) {
       showError(
         Visible_Error_Messages.UpdateAdminPerms.title,
         Visible_Error_Messages.UpdateAdminPerms.description

--- a/cv_next/app/admin/components/permsDropDown.tsx
+++ b/cv_next/app/admin/components/permsDropDown.tsx
@@ -15,10 +15,13 @@ export const PermsDropDown = ({
   currentPerms,
 }: {
   userId: string;
-  currentPerms: string;
+  currentPerms: keyof typeof PermsKeys.user_types_enum;
 }) => {
-  const [newPerms, setNewPerms] = useState<string>(currentPerms);
-  const { handleSubmit, register } = useForm<FormValues>({ mode: "onChange" });
+  const [newPerms, setNewPerms] =
+    useState<keyof typeof PermsKeys.user_types_enum>(currentPerms);
+  const { handleSubmit, register, reset } = useForm<FormValues>({
+    mode: "onChange",
+  });
   const { showError } = useError();
 
   const handleOnSubmit: SubmitHandler<FormValues> = async (data) => {
@@ -30,6 +33,7 @@ export const PermsDropDown = ({
         Visible_Error_Messages.UpdateAdminPerms.title,
         Visible_Error_Messages.UpdateAdminPerms.description
       );
+      reset({ perms: newPerms });
       return;
     }
     setNewPerms(data.perms);
@@ -50,7 +54,20 @@ export const PermsDropDown = ({
       <div className="flex flex-wrap justify-center text-center">
         <select
           id="perms"
-          {...register("perms", { required: "Permission level is required" })}
+          {...register("perms", {
+            required: "Permission level is required",
+            validate: (value) => {
+              if (value === "admin" || currentPerms === "admin") {
+                showError(
+                  Visible_Error_Messages.UpdateAdminPerms.title,
+                  Visible_Error_Messages.UpdateAdminPerms.description
+                );
+                reset({ perms: newPerms });
+                return false;
+              }
+              return true;
+            },
+          })}
           defaultValue={newPerms}
           className="rounded-full px-3 py-1 text-sm font-medium"
           style={{

--- a/cv_next/app/admin/components/permsDropDown.tsx
+++ b/cv_next/app/admin/components/permsDropDown.tsx
@@ -2,6 +2,8 @@
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useState } from "react";
 import { PermsKeys } from "@/lib/supabase-definitions";
+import { useError } from "@/providers/error-provider";
+import { Visible_Error_Messages } from "@/lib/definitions";
 
 type FormValues = {
   perms: keyof typeof PermsKeys.user_types_enum;
@@ -16,8 +18,16 @@ export const PermsDropDown = ({
 }) => {
   const [newPerms, setNewPerms] = useState<string>(currentPerms);
   const { handleSubmit, register } = useForm<FormValues>({ mode: "onChange" });
+  const { showError } = useError();
 
   const handleOnSubmit: SubmitHandler<FormValues> = async (data) => {
+    if (currentPerms === PermsKeys.user_types_enum.admin) {
+      showError(
+        Visible_Error_Messages.UpdateAdminPerms.title,
+        Visible_Error_Messages.UpdateAdminPerms.description
+      );
+      return;
+    }
     setNewPerms(data.perms);
     console.log(data);
   };

--- a/cv_next/app/admin/components/profilesTable.tsx
+++ b/cv_next/app/admin/components/profilesTable.tsx
@@ -1,5 +1,6 @@
 "use server";
 import Image from "next/image";
+import Link from "next/link";
 import { PermsDropDown } from "./permsDropDown";
 
 export const ProfilesTable = ({
@@ -30,7 +31,12 @@ export const ProfilesTable = ({
                 {profile.display_name}
               </td>
               <td className="whitespace-nowrap border p-4 ">
-                {profile.username}
+                <Link
+                  className=" hover:underline"
+                  href={`/profile/${profile.username}`}
+                >
+                  {profile.username}
+                </Link>
               </td>
               {profile.avatar_url ? (
                 <td className="border p-4 text-center">

--- a/cv_next/app/admin/components/profilesTable.tsx
+++ b/cv_next/app/admin/components/profilesTable.tsx
@@ -1,0 +1,62 @@
+"use server";
+import Image from "next/image";
+import { PermsDropDown } from "./permsDropDown";
+
+export const ProfilesTable = ({
+  profiles,
+}: {
+  profiles: Partial<UserWithPerms>[];
+}) => {
+  return (
+    <div className="w-full rounded-lg shadow-md">
+      <table className="mx-auto w-full max-w-full rounded-lg border border-gray-300 bg-white text-center dark:border-gray-700 dark:bg-black">
+        <thead className="bg-gray-100 dark:bg-gray-900">
+          <tr className=" text-sm uppercase text-gray-700 dark:text-gray-300">
+            <th className="whitespace-nowrap border p-4">ID</th>
+            <th className="whitespace-nowrap border p-4">Display Name</th>
+            <th className="whitespace-nowrap border p-4">Username</th>
+            <th className="whitespace-nowrap border p-4">Avatar</th>
+            <th className="whitespace-nowrap border p-4">User Type</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          {profiles.map((profile) => (
+            <tr key={profile.id}>
+              <td className="whitespace-nowrap border p-4 text-gray-700 dark:text-gray-300">
+                {profile.id}
+              </td>
+              <td className="whitespace-nowrap border p-4 font-medium">
+                {profile.display_name}
+              </td>
+              <td className="whitespace-nowrap border p-4 ">
+                {profile.username}
+              </td>
+              {profile.avatar_url ? (
+                <td className="border p-4 text-center">
+                  <div className="relative mx-auto h-12 w-12">
+                    <Image
+                      src={profile.avatar_url}
+                      alt={profile.display_name || ""}
+                      width={125}
+                      height={75}
+                      className="h-full w-full rounded-full border object-contain"
+                    />
+                  </div>
+                </td>
+              ) : (
+                <td />
+              )}
+              <td className="whitespace-nowrap border p-4">
+                <PermsDropDown
+                  userId={profile.id || ""}
+                  currentPerms={profile.user_type || ""}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/cv_next/app/admin/components/profilesTable.tsx
+++ b/cv_next/app/admin/components/profilesTable.tsx
@@ -31,12 +31,16 @@ export const ProfilesTable = ({
                 {profile.display_name}
               </td>
               <td className="whitespace-nowrap border p-4 ">
-                <Link
-                  className=" hover:underline"
-                  href={`/profile/${profile.username}`}
-                >
-                  {profile.username}
-                </Link>
+                {profile.username ? (
+                  <Link
+                    className=" hover:underline"
+                    href={`/profile/${profile.username}`}
+                  >
+                    {profile.username}
+                  </Link>
+                ) : (
+                  <span className="text-gray-400">No username</span>
+                )}
               </td>
               {profile.avatar_url ? (
                 <td className="border p-4 text-center">

--- a/cv_next/app/admin/components/quickActions.tsx
+++ b/cv_next/app/admin/components/quickActions.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useError } from "@/providers/error-provider";
+import { Button } from "@/app/feed/components/button";
+import { activateUsers } from "@/app/actions/users/updateUser";
+
+export const QuickActions = () => {
+  const { showError } = useError();
+  const activateAll = async () => {
+    const res = await activateUsers();
+    if (res.ok) {
+      window.location.reload();
+    } else {
+      showError(
+        "",
+        res.errors.postgrestError?.message ||
+          res.errors.authError?.message ||
+          res.errors.err?.message ||
+          "Unknown error"
+      );
+    }
+  };
+
+  return (
+    <div className="mx-auto mb-3 flex max-w-36 justify-end">
+      <Button text="Activate All" onClick={activateAll} />
+    </div>
+  );
+};

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -1,6 +1,13 @@
 "use server";
 import Image from "next/image";
+import { Metadata } from "next";
 import { getAllUsers } from "@/server/api/users";
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: "Admin Panel",
+  };
+}
 
 export default async function Page() {
   const users = await getAllUsers();
@@ -8,7 +15,7 @@ export default async function Page() {
     return (
       <div className="mx-auto mt-10 ">
         <h1 className="mb-6 text-center text-2xl font-semibold">
-          User Profiles
+          Admin Panel - User Approvals
         </h1>
 
         <div className="w-full rounded-lg shadow-md">

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -1,8 +1,8 @@
 "use server";
-import Image from "next/image";
 import { Metadata } from "next";
 import { getAllUsers } from "@/server/api/users";
-import { PermsDropDown } from "./components/permsDropDown";
+import { ScrollToTop } from "@/components/ui/scrollToTop";
+import { ProfilesTable } from "./components/profilesTable";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -12,65 +12,15 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page() {
   const users = await getAllUsers();
-  if (users.ok) {
-    return (
+
+  return (
+    <div>
+      <ScrollToTop />
       <div className="mx-auto mt-10 ">
-        <h1 className="mb-6 text-center text-2xl font-semibold">
-          Admin Panel - User Approvals
-        </h1>
+        <h1 className="mb-6 text-center text-2xl font-semibold">Admin Panel</h1>
 
-        <div className="w-full rounded-lg shadow-md">
-          <table className="mx-auto w-full max-w-full rounded-lg border border-gray-300 bg-white text-center dark:border-gray-700 dark:bg-black">
-            <thead className="bg-gray-100 dark:bg-gray-900">
-              <tr className=" text-sm uppercase text-gray-700 dark:text-gray-300">
-                <th className="whitespace-nowrap border p-4">ID</th>
-                <th className="whitespace-nowrap border p-4">Display Name</th>
-                <th className="whitespace-nowrap border p-4">Username</th>
-                <th className="whitespace-nowrap border p-4">Avatar</th>
-                <th className="whitespace-nowrap border p-4">User Type</th>
-              </tr>
-            </thead>
-
-            <tbody>
-              {users.val.map((profile) => (
-                <tr key={profile.id}>
-                  <td className="whitespace-nowrap border p-4 text-gray-700 dark:text-gray-300">
-                    {profile.id}
-                  </td>
-                  <td className="whitespace-nowrap border p-4 font-medium">
-                    {profile.display_name}
-                  </td>
-                  <td className="whitespace-nowrap border p-4 ">
-                    {profile.username}
-                  </td>
-                  {profile.avatar_url ? (
-                    <td className="border p-4 text-center">
-                      <div className="relative mx-auto h-12 w-12">
-                        <Image
-                          src={profile.avatar_url}
-                          alt={profile.display_name || ""}
-                          width={125}
-                          height={75}
-                          className="h-full w-full rounded-full border object-contain"
-                        />
-                      </div>
-                    </td>
-                  ) : (
-                    <td />
-                  )}
-                  <td className="whitespace-nowrap border p-4">
-                    <PermsDropDown
-                      userId={profile.id || ""}
-                      currentPerms={profile.user_type || ""}
-                    />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        {users.ok && <ProfilesTable profiles={users.val} />}
       </div>
-    );
-  }
-  return <div>Error: {users.errors as string}</div>;
+    </div>
+  );
 }

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -1,7 +1,7 @@
 "use server";
 import { Metadata } from "next";
-import { getAllUsers } from "@/server/api/users";
 import { ScrollToTop } from "@/components/ui/scrollToTop";
+import { getAllUsersPerms } from "@/app/actions/users/getUser";
 import { ProfilesTable } from "./components/profilesTable";
 import { QuickActions } from "./components/quickActions";
 
@@ -12,7 +12,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Page() {
-  const users = await getAllUsers();
+  const users = await getAllUsersPerms();
 
   return (
     <div>

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -59,19 +59,6 @@ export default async function Page() {
                     <td />
                   )}
                   <td className="whitespace-nowrap border p-4">
-                    {/* <span
-                      className="rounded-full px-3 py-1 text-sm font-medium"
-                      style={{
-                        backgroundColor:
-                          profile.user_type === "inactive"
-                            ? "#EF4444"
-                            : profile.user_type === "admin"
-                              ? "#F59E0B"
-                              : "#10B981",
-                      }}
-                    >
-                      {profile.user_type}
-                    </span> */}
                     <PermsDropDown
                       userId={profile.id || ""}
                       currentPerms={profile.user_type || ""}

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -2,6 +2,7 @@
 import Image from "next/image";
 import { Metadata } from "next";
 import { getAllUsers } from "@/server/api/users";
+import { PermsDropDown } from "./components/permsDropDown";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -58,7 +59,7 @@ export default async function Page() {
                     <td />
                   )}
                   <td className="whitespace-nowrap border p-4">
-                    <span
+                    {/* <span
                       className="rounded-full px-3 py-1 text-sm font-medium"
                       style={{
                         backgroundColor:
@@ -70,7 +71,11 @@ export default async function Page() {
                       }}
                     >
                       {profile.user_type}
-                    </span>
+                    </span> */}
+                    <PermsDropDown
+                      userId={profile.id || ""}
+                      currentPerms={profile.user_type || ""}
+                    />
                   </td>
                 </tr>
               ))}

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -16,14 +16,13 @@ export default async function Page() {
             <thead className="bg-gray-100 dark:bg-gray-900">
               <tr className=" text-sm uppercase text-gray-700 dark:text-gray-300">
                 <th className="whitespace-nowrap border p-4">ID</th>
-                <th className="whitespace-nowrap border p-4">Username</th>
                 <th className="whitespace-nowrap border p-4">Display Name</th>
+                <th className="whitespace-nowrap border p-4">Username</th>
                 <th className="whitespace-nowrap border p-4">Avatar</th>
                 <th className="whitespace-nowrap border p-4">User Type</th>
               </tr>
             </thead>
 
-            {/* Table Body */}
             <tbody>
               {users.val.map((profile) => (
                 <tr key={profile.id}>
@@ -31,10 +30,10 @@ export default async function Page() {
                     {profile.id}
                   </td>
                   <td className="whitespace-nowrap border p-4 font-medium">
-                    {profile.username}
-                  </td>
-                  <td className="whitespace-nowrap border p-4">
                     {profile.display_name}
+                  </td>
+                  <td className="whitespace-nowrap border p-4 ">
+                    {profile.username}
                   </td>
                   {profile.avatar_url ? (
                     <td className="border p-4 text-center">

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -42,9 +42,9 @@ export default async function Page() {
                         <Image
                           src={profile.avatar_url}
                           alt={profile.display_name || ""}
-                          layout="fill"
-                          objectFit="cover"
-                          className="rounded-full border"
+                          width={125}
+                          height={75}
+                          className="h-full w-full rounded-full border object-contain"
                         />
                       </div>
                     </td>

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -16,7 +16,7 @@ export default async function Page() {
   return (
     <div>
       <ScrollToTop />
-      <div className="mx-auto mt-10 ">
+      <div className="mx-auto mt-4">
         <h1 className="mb-6 text-center text-2xl font-semibold">Admin Panel</h1>
 
         {users.ok && <ProfilesTable profiles={users.val} />}

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import { getAllUsers } from "@/server/api/users";
 import { ScrollToTop } from "@/components/ui/scrollToTop";
 import { ProfilesTable } from "./components/profilesTable";
+import { QuickActions } from "./components/quickActions";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -18,6 +19,7 @@ export default async function Page() {
       <ScrollToTop />
       <div className="mx-auto mt-4">
         <h1 className="mb-6 text-center text-2xl font-semibold">Admin Panel</h1>
+        <QuickActions />
 
         {users.ok && <ProfilesTable profiles={users.val} />}
       </div>

--- a/cv_next/app/admin/page.tsx
+++ b/cv_next/app/admin/page.tsx
@@ -1,0 +1,78 @@
+"use server";
+import Image from "next/image";
+import { getAllUsers } from "@/server/api/users";
+
+export default async function Page() {
+  const users = await getAllUsers();
+  if (users.ok) {
+    return (
+      <div className="mx-auto mt-10 ">
+        <h1 className="mb-6 text-center text-2xl font-semibold">
+          User Profiles
+        </h1>
+
+        <div className="w-full rounded-lg shadow-md">
+          <table className="mx-auto w-full max-w-full rounded-lg border border-gray-300 bg-white text-center dark:border-gray-700 dark:bg-black">
+            <thead className="bg-gray-100 dark:bg-gray-900">
+              <tr className=" text-sm uppercase text-gray-700 dark:text-gray-300">
+                <th className="whitespace-nowrap border p-4">ID</th>
+                <th className="whitespace-nowrap border p-4">Username</th>
+                <th className="whitespace-nowrap border p-4">Display Name</th>
+                <th className="whitespace-nowrap border p-4">Avatar</th>
+                <th className="whitespace-nowrap border p-4">User Type</th>
+              </tr>
+            </thead>
+
+            {/* Table Body */}
+            <tbody>
+              {users.val.map((profile) => (
+                <tr key={profile.id}>
+                  <td className="whitespace-nowrap border p-4 text-gray-700 dark:text-gray-300">
+                    {profile.id}
+                  </td>
+                  <td className="whitespace-nowrap border p-4 font-medium">
+                    {profile.username}
+                  </td>
+                  <td className="whitespace-nowrap border p-4">
+                    {profile.display_name}
+                  </td>
+                  {profile.avatar_url ? (
+                    <td className="border p-4 text-center">
+                      <div className="relative mx-auto h-12 w-12">
+                        <Image
+                          src={profile.avatar_url}
+                          alt={profile.display_name || ""}
+                          layout="fill"
+                          objectFit="cover"
+                          className="rounded-full border"
+                        />
+                      </div>
+                    </td>
+                  ) : (
+                    <td />
+                  )}
+                  <td className="whitespace-nowrap border p-4">
+                    <span
+                      className="rounded-full px-3 py-1 text-sm font-medium"
+                      style={{
+                        backgroundColor:
+                          profile.user_type === "inactive"
+                            ? "#EF4444"
+                            : profile.user_type === "admin"
+                              ? "#F59E0B"
+                              : "#10B981",
+                      }}
+                    >
+                      {profile.user_type}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+  return <div>Error: {users.errors as string}</div>;
+}

--- a/cv_next/app/global.d.ts
+++ b/cv_next/app/global.d.ts
@@ -1,7 +1,7 @@
 import { PostgrestError, AuthError } from "@supabase/supabase-js";
 import { UI_Location } from "@/lib/definitions";
 import { Database as DB } from "@/types/database.types";
-
+import { PermsKeys } from "@/lib/supabase-definitions";
 declare global {
   type Database = DB;
   type CvModel = DB["public"]["Tables"]["cvs"]["Row"];
@@ -49,5 +49,5 @@ declare global {
     UILocation: UILocation;
   };
 
-  type UserWithPerms = UserModel & { user_type: string };
+  type UserWithPerms = UserModel & { user_type: PermsKeys.user_types_enum };
 }

--- a/cv_next/app/global.d.ts
+++ b/cv_next/app/global.d.ts
@@ -48,4 +48,6 @@ declare global {
     image: string;
     UILocation: UILocation;
   };
+
+  type UserWithPerms = UserModel & { user_type: string };
 }

--- a/cv_next/lib/definitions.ts
+++ b/cv_next/lib/definitions.ts
@@ -135,6 +135,12 @@ export const Visible_Error_Messages: ErrorMessages = {
     title: "Your CV is set to private!",
     description: "Please update your CV settings to make it public again.",
   },
+  UpdateAdminPerms: {
+    keyword: "UpdateAdminPerms",
+    title: "You can't change the permissions of an admin from the website",
+    description:
+      "Please go to the console to change the permissions of an admin.",
+  },
   DefaultError: {
     keyword: "default",
     title: "An Error Occurred",

--- a/cv_next/lib/supabase-definitions.ts
+++ b/cv_next/lib/supabase-definitions.ts
@@ -83,7 +83,7 @@ export const CommentKeys: {
 export const PermsKeys: {
   id: "id";
   user_type: "user_type";
-  user_types: {
+  user_types_enum: {
     inactive: "inactive";
     active: "active";
     admin: "admin";
@@ -91,7 +91,7 @@ export const PermsKeys: {
 } = {
   id: "id",
   user_type: "user_type",
-  user_types: {
+  user_types_enum: {
     inactive: "inactive",
     active: "active",
     admin: "admin",

--- a/cv_next/lib/supabase-definitions.ts
+++ b/cv_next/lib/supabase-definitions.ts
@@ -4,12 +4,14 @@ export const Tables: {
   profiles: "profiles";
   whitelisted: "whitelisted";
   admins: "admins";
+  profiles_perms: "profiles_perms";
 } = {
   cvs: "cvs",
   comments: "comments",
   profiles: "profiles",
   whitelisted: "whitelisted",
   admins: "admins",
+  profiles_perms: "profiles_perms",
 };
 
 export const CvKeys: {
@@ -43,11 +45,6 @@ export const ProfileKeys: {
     hiring: "hiring";
     nothing: "nothing";
   };
-  user_types: {
-    inactive: "inactive";
-    active: "active";
-    admin: "admin";
-  };
 } = {
   avatar_url: "avatar_url",
   display_name: "display_name",
@@ -58,11 +55,6 @@ export const ProfileKeys: {
     open_to_work: "open to work",
     hiring: "hiring",
     nothing: "nothing",
-  },
-  user_types: {
-    inactive: "inactive",
-    active: "active",
-    admin: "admin",
   },
 };
 
@@ -86,6 +78,24 @@ export const CommentKeys: {
   id: "id",
   resolved: "resolved",
   user_id: "user_id",
+};
+
+export const PermsKeys: {
+  id: "id";
+  user_type: "user_type";
+  user_types: {
+    inactive: "inactive";
+    active: "active";
+    admin: "admin";
+  };
+} = {
+  id: "id",
+  user_type: "user_type",
+  user_types: {
+    inactive: "inactive",
+    active: "active",
+    admin: "admin",
+  },
 };
 
 export const Storage: {

--- a/cv_next/middleware.ts
+++ b/cv_next/middleware.ts
@@ -47,6 +47,19 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(nextUrl);
   }
 
+  if (request.nextUrl.pathname == "/admin") {
+    const { data: admins, error: errorWhitelist } = await supabase
+      .from(Tables.admins)
+      .select("*")
+      .eq(ProfileKeys.id, activatedUser.user.id)
+      .single();
+    if (admins?.id == null || errorWhitelist) {
+      const nextUrl = new URL(`/not_found`, request.url);
+      return NextResponse.redirect(nextUrl);
+    }
+    return supabaseResponse;
+  }
+
   const { data: whitelisted, error: errorWhitelist } = await supabase
     .from(Tables.whitelisted)
     .select("*")
@@ -71,5 +84,6 @@ export const config = {
     "/upload",
     "/hall",
     "/first_login/:profileUsername*",
+    "/admin",
   ],
 };

--- a/cv_next/server/api/users.ts
+++ b/cv_next/server/api/users.ts
@@ -493,6 +493,13 @@ export async function getAllUsers(
 export const updateUserPerms = async (
   user: Partial<UserWithPerms>
 ): Promise<Result<void, string>> => {
+  const resultAdminCheck = await userIsAdmin();
+  if (!resultAdminCheck.ok) {
+    return Err(updateUserPerms.name, {
+      err: "You are not an admin" as unknown as Error,
+    });
+  }
+
   if (user?.id === undefined || user?.user_type === undefined) {
     return Err(updateUserPerms.name, {
       err: Error("User ID or Permissions aren't undefined"),

--- a/cv_next/server/api/users.ts
+++ b/cv_next/server/api/users.ts
@@ -484,3 +484,33 @@ export async function getAllUsers(
     });
   }
 }
+
+/**
+ * Updates the user_type of a given user id.
+ * @param user The user object to update.
+ * @returns A promise that resolves with void or rejects with an error message.
+ */
+export const updateUserPerms = async (
+  user: Partial<UserWithPerms>
+): Promise<Result<void, string>> => {
+  if (user?.id === undefined || user?.user_type === undefined) {
+    return Err(updateUserPerms.name, {
+      err: Error("User ID or Permissions aren't undefined"),
+    });
+  }
+  const { id, user_type } = user;
+  try {
+    const { error } = await SupabaseHelper.getSupabaseInstance()
+      .from(Tables.profiles_perms)
+      .update({ user_type })
+      .eq(ProfileKeys.id, id);
+    if (error) {
+      return Err(updateUserPerms.name, { postgrestError: error });
+    }
+    return Ok.EMPTY;
+  } catch (err) {
+    return Err(updateUserPerms.name, {
+      err: err as Error,
+    });
+  }
+};

--- a/cv_next/server/api/users.ts
+++ b/cv_next/server/api/users.ts
@@ -465,6 +465,7 @@ export async function getAllUsers(
     const { data: users, error } = await query;
 
     if (error) {
+      logger.error("Failed to fetch all users", error);
       return Err(getAllUsers.name, { postgrestError: error });
     }
     const usersWithPerms: PermissionsWithUserData = users;
@@ -479,6 +480,7 @@ export async function getAllUsers(
 
     return Ok(transformedData as Partial<UserWithPerms>[]);
   } catch (err) {
+    logger.error("Failed to fetch all users", err);
     return Err(getAllUsers.name, {
       err: err as Error,
     });
@@ -495,6 +497,7 @@ export const updateUserPerms = async (
 ): Promise<Result<void, string>> => {
   const resultAdminCheck = await userIsAdmin();
   if (!resultAdminCheck.ok) {
+    logger.error("None admin action detected.");
     return Err(updateUserPerms.name, {
       err: "You are not an admin" as unknown as Error,
     });
@@ -512,6 +515,7 @@ export const updateUserPerms = async (
       .update({ user_type })
       .eq(ProfileKeys.id, id);
     if (error) {
+      logger.error("Failed to activate the user", error);
       return Err(updateUserPerms.name, { postgrestError: error });
     }
     return Ok.EMPTY;

--- a/cv_next/server/api/users.ts
+++ b/cv_next/server/api/users.ts
@@ -525,3 +525,34 @@ export const updateUserPerms = async (
     });
   }
 };
+
+/**
+ * Activates all users.
+ * @returns {Promise<Result<void, string>>} A promise that resolves with void or rejects with an error message.
+ */
+export const activateAllUsers = async (): Promise<Result<void, string>> => {
+  const resultAdminCheck = await userIsAdmin();
+  if (!resultAdminCheck.ok) {
+    logger.error("None admin action detected.");
+    return Err(activateAllUsers.name, {
+      err: "You are not an admin" as unknown as Error,
+    });
+  }
+
+  try {
+    const { error } = await SupabaseHelper.getSupabaseInstance()
+      .from(Tables.profiles_perms)
+      .update({ user_type: PermsKeys.user_types_enum.active })
+      .eq(PermsKeys.user_type, PermsKeys.user_types_enum.inactive);
+    if (error) {
+      logger.error("Failed to activate all users", error);
+      return Err(activateAllUsers.name, { postgrestError: error });
+    }
+    return Ok.EMPTY;
+  } catch (err) {
+    logger.error("Failed to activate all users", err);
+    return Err(activateAllUsers.name, {
+      err: err as Error,
+    });
+  }
+};

--- a/cv_next/server/api/users.ts
+++ b/cv_next/server/api/users.ts
@@ -487,8 +487,8 @@ export async function getAllUsers(
 
 /**
  * Updates the user_type of a given user id.
- * @param user The user object to update.
- * @returns A promise that resolves with void or rejects with an error message.
+ * @param {Partial<UserWithPerms>} user The user object to update.
+ * @returns {Promise<Result<void, string>>} A promise that resolves with void or rejects with an error message.
  */
 export const updateUserPerms = async (
   user: Partial<UserWithPerms>

--- a/cv_next/server/api/users.ts
+++ b/cv_next/server/api/users.ts
@@ -454,7 +454,8 @@ export async function getAllUsers(
       .from(Tables.profiles_perms)
       .select(
         `*, ${Tables.profiles}(${ProfileKeys.id}, ${ProfileKeys.display_name}, ${ProfileKeys.username}, ${ProfileKeys.avatar_url})`
-      );
+      )
+      .order(PermsKeys.user_type, { ascending: true });
 
     type PermissionsWithUserData = QueryData<typeof query>;
 

--- a/cv_next/types/database.types.ts
+++ b/cv_next/types/database.types.ts
@@ -7,6 +7,31 @@ export type Json =
   | Json[];
 
 export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never;
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      graphql: {
+        Args: {
+          operationName?: string;
+          query?: string;
+          variables?: Json;
+          extensions?: Json;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
   public: {
     Tables: {
       comments: {
@@ -30,7 +55,7 @@ export type Database = {
           parent_comment_Id?: string | null;
           resolved?: boolean;
           upvotes?: string[] | null;
-          user_id: string;
+          user_id?: string;
         };
         Update: {
           data?: string;
@@ -62,21 +87,7 @@ export type Database = {
             foreignKeyName: "public_comments_user_id_fkey";
             columns: ["user_id"];
             isOneToOne: false;
-            referencedRelation: "admins";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "public_comments_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
             referencedRelation: "profiles";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "public_comments_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "whitelisted";
             referencedColumns: ["id"];
           },
         ];
@@ -84,7 +95,7 @@ export type Database = {
       cvs: {
         Row: {
           created_at: string;
-          cv_categories: number[];
+          cv_categories: number[] | null;
           deleted: boolean;
           description: string;
           document_link: string;
@@ -94,7 +105,7 @@ export type Database = {
         };
         Insert: {
           created_at?: string;
-          cv_categories: number[];
+          cv_categories?: number[] | null;
           deleted?: boolean;
           description: string;
           document_link: string;
@@ -104,7 +115,7 @@ export type Database = {
         };
         Update: {
           created_at?: string;
-          cv_categories?: number[];
+          cv_categories?: number[] | null;
           deleted?: boolean;
           description?: string;
           document_link?: string;
@@ -114,10 +125,10 @@ export type Database = {
         };
         Relationships: [
           {
-            foreignKeyName: "cvs_user_id_fkey";
+            foreignKeyName: "cvs_user_id_fkey1";
             columns: ["user_id"];
             isOneToOne: false;
-            referencedRelation: "users";
+            referencedRelation: "profiles";
             referencedColumns: ["id"];
           },
         ];
@@ -135,7 +146,7 @@ export type Database = {
         Insert: {
           avatar_url?: string | null;
           display_name?: string | null;
-          id: string;
+          id?: string;
           updated_at?: string | null;
           username?: string | null;
           work_status?: Database["public"]["Enums"]["work_status"];
@@ -150,12 +161,27 @@ export type Database = {
           work_status?: Database["public"]["Enums"]["work_status"];
           work_status_categories?: number[] | null;
         };
+        Relationships: [];
+      };
+      profiles_perms: {
+        Row: {
+          id: string;
+          user_type: Database["public"]["Enums"]["user_type"];
+        };
+        Insert: {
+          id?: string;
+          user_type?: Database["public"]["Enums"]["user_type"];
+        };
+        Update: {
+          id?: string;
+          user_type?: Database["public"]["Enums"]["user_type"];
+        };
         Relationships: [
           {
-            foreignKeyName: "profiles_id_fkey";
+            foreignKeyName: "profiles_perms_id_fkey1";
             columns: ["id"];
             isOneToOne: true;
-            referencedRelation: "users";
+            referencedRelation: "profiles";
             referencedColumns: ["id"];
           },
         ];
@@ -174,10 +200,10 @@ export type Database = {
         };
         Relationships: [
           {
-            foreignKeyName: "profiles_id_fkey";
+            foreignKeyName: "profiles_perms_id_fkey1";
             columns: ["id"];
             isOneToOne: true;
-            referencedRelation: "users";
+            referencedRelation: "profiles";
             referencedColumns: ["id"];
           },
         ];
@@ -194,10 +220,10 @@ export type Database = {
         };
         Relationships: [
           {
-            foreignKeyName: "profiles_id_fkey";
+            foreignKeyName: "profiles_perms_id_fkey1";
             columns: ["id"];
             isOneToOne: true;
-            referencedRelation: "users";
+            referencedRelation: "profiles";
             referencedColumns: ["id"];
           },
         ];
@@ -212,10 +238,331 @@ export type Database = {
         Args: Record<PropertyKey, never>;
         Returns: string[];
       };
+      is_admin: {
+        Args: {
+          uid: string;
+        };
+        Returns: boolean;
+      };
     };
     Enums: {
       user_type: "inactive" | "active" | "admin";
       work_status: "open_to_work" | "hiring" | "nothing";
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+  storage: {
+    Tables: {
+      buckets: {
+        Row: {
+          allowed_mime_types: string[] | null;
+          avif_autodetection: boolean | null;
+          created_at: string | null;
+          file_size_limit: number | null;
+          id: string;
+          name: string;
+          owner: string | null;
+          owner_id: string | null;
+          public: boolean | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id: string;
+          name: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          allowed_mime_types?: string[] | null;
+          avif_autodetection?: boolean | null;
+          created_at?: string | null;
+          file_size_limit?: number | null;
+          id?: string;
+          name?: string;
+          owner?: string | null;
+          owner_id?: string | null;
+          public?: boolean | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+      migrations: {
+        Row: {
+          executed_at: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
+        Insert: {
+          executed_at?: string | null;
+          hash: string;
+          id: number;
+          name: string;
+        };
+        Update: {
+          executed_at?: string | null;
+          hash?: string;
+          id?: number;
+          name?: string;
+        };
+        Relationships: [];
+      };
+      objects: {
+        Row: {
+          bucket_id: string | null;
+          created_at: string | null;
+          id: string;
+          last_accessed_at: string | null;
+          metadata: Json | null;
+          name: string | null;
+          owner: string | null;
+          owner_id: string | null;
+          path_tokens: string[] | null;
+          updated_at: string | null;
+          user_metadata: Json | null;
+          version: string | null;
+        };
+        Insert: {
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          user_metadata?: Json | null;
+          version?: string | null;
+        };
+        Update: {
+          bucket_id?: string | null;
+          created_at?: string | null;
+          id?: string;
+          last_accessed_at?: string | null;
+          metadata?: Json | null;
+          name?: string | null;
+          owner?: string | null;
+          owner_id?: string | null;
+          path_tokens?: string[] | null;
+          updated_at?: string | null;
+          user_metadata?: Json | null;
+          version?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "objects_bucketId_fkey";
+            columns: ["bucket_id"];
+            isOneToOne: false;
+            referencedRelation: "buckets";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      s3_multipart_uploads: {
+        Row: {
+          bucket_id: string;
+          created_at: string;
+          id: string;
+          in_progress_size: number;
+          key: string;
+          owner_id: string | null;
+          upload_signature: string;
+          user_metadata: Json | null;
+          version: string;
+        };
+        Insert: {
+          bucket_id: string;
+          created_at?: string;
+          id: string;
+          in_progress_size?: number;
+          key: string;
+          owner_id?: string | null;
+          upload_signature: string;
+          user_metadata?: Json | null;
+          version: string;
+        };
+        Update: {
+          bucket_id?: string;
+          created_at?: string;
+          id?: string;
+          in_progress_size?: number;
+          key?: string;
+          owner_id?: string | null;
+          upload_signature?: string;
+          user_metadata?: Json | null;
+          version?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_bucket_id_fkey";
+            columns: ["bucket_id"];
+            isOneToOne: false;
+            referencedRelation: "buckets";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      s3_multipart_uploads_parts: {
+        Row: {
+          bucket_id: string;
+          created_at: string;
+          etag: string;
+          id: string;
+          key: string;
+          owner_id: string | null;
+          part_number: number;
+          size: number;
+          upload_id: string;
+          version: string;
+        };
+        Insert: {
+          bucket_id: string;
+          created_at?: string;
+          etag: string;
+          id?: string;
+          key: string;
+          owner_id?: string | null;
+          part_number: number;
+          size?: number;
+          upload_id: string;
+          version: string;
+        };
+        Update: {
+          bucket_id?: string;
+          created_at?: string;
+          etag?: string;
+          id?: string;
+          key?: string;
+          owner_id?: string | null;
+          part_number?: number;
+          size?: number;
+          upload_id?: string;
+          version?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_bucket_id_fkey";
+            columns: ["bucket_id"];
+            isOneToOne: false;
+            referencedRelation: "buckets";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "s3_multipart_uploads_parts_upload_id_fkey";
+            columns: ["upload_id"];
+            isOneToOne: false;
+            referencedRelation: "s3_multipart_uploads";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      can_insert_object: {
+        Args: {
+          bucketid: string;
+          name: string;
+          owner: string;
+          metadata: Json;
+        };
+        Returns: undefined;
+      };
+      extension: {
+        Args: {
+          name: string;
+        };
+        Returns: string;
+      };
+      filename: {
+        Args: {
+          name: string;
+        };
+        Returns: string;
+      };
+      foldername: {
+        Args: {
+          name: string;
+        };
+        Returns: string[];
+      };
+      get_size_by_bucket: {
+        Args: Record<PropertyKey, never>;
+        Returns: {
+          size: number;
+          bucket_id: string;
+        }[];
+      };
+      list_multipart_uploads_with_delimiter: {
+        Args: {
+          bucket_id: string;
+          prefix_param: string;
+          delimiter_param: string;
+          max_keys?: number;
+          next_key_token?: string;
+          next_upload_token?: string;
+        };
+        Returns: {
+          key: string;
+          id: string;
+          created_at: string;
+        }[];
+      };
+      list_objects_with_delimiter: {
+        Args: {
+          bucket_id: string;
+          prefix_param: string;
+          delimiter_param: string;
+          max_keys?: number;
+          start_after?: string;
+          next_token?: string;
+        };
+        Returns: {
+          name: string;
+          id: string;
+          metadata: Json;
+          updated_at: string;
+        }[];
+      };
+      operation: {
+        Args: Record<PropertyKey, never>;
+        Returns: string;
+      };
+      search: {
+        Args: {
+          prefix: string;
+          bucketname: string;
+          limits?: number;
+          levels?: number;
+          offsets?: number;
+          search?: string;
+          sortcolumn?: string;
+          sortorder?: string;
+        };
+        Returns: {
+          name: string;
+          id: string;
+          updated_at: string;
+          created_at: string;
+          last_accessed_at: string;
+          metadata: Json;
+        }[];
+      };
+    };
+    Enums: {
+      [_ in never]: never;
     };
     CompositeTypes: {
       [_ in never]: never;
@@ -303,4 +650,19 @@ export type Enums<
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
     ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never;
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database;
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never;


### PR DESCRIPTION
This PR adds the ability to activate and deactivate users from the website(only admins can do this, and admins can't be created or demoted).
This is how it looks:
![image](https://github.com/user-attachments/assets/d279c014-896f-4c31-981d-c51cc31d102d)

Currently, it's a long table with inactive users at the top and admins at the bottom, not sure if filtering is a must at the moment.
The username also redirects to their profile.
