### PR TITLE
365 bug   private cvs edit page isnt reachable

### DIFF
--- a/cv_next/app/cv/[cvId]/components/cvData.tsx
+++ b/cv_next/app/cv/[cvId]/components/cvData.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FiSettings } from "react-icons/fi";
+import { useEffect } from "react";
 import DynamicProfileImage from "@/components/ui/DynamicProfileImage";
 import { useError } from "@/providers/error-provider";
 import { Visible_Error_Messages } from "@/lib/definitions";
@@ -32,20 +33,23 @@ export default function CvData({
   const { showError } = useError();
   const router = useRouter();
 
-  if (!validCV) {
-    if (canEditCv) {
-      showError(
-        Visible_Error_Messages.CurrentUserPrivateCV.title,
-        Visible_Error_Messages.CurrentUserPrivateCV.description
-      );
-    } else {
-      showError(
-        Visible_Error_Messages.PrivateCV.title,
-        Visible_Error_Messages.PrivateCV.description,
-        () => router.push("/feed")
-      );
+  useEffect(() => {
+    if (!validCV) {
+      if (canEditCv) {
+        showError(
+          Visible_Error_Messages.CurrentUserPrivateCV.title,
+          Visible_Error_Messages.CurrentUserPrivateCV.description,
+          () => router.push(`/cv/${encodeValue(cv.id)}/edit`)
+        );
+      } else {
+        showError(
+          Visible_Error_Messages.PrivateCV.title,
+          Visible_Error_Messages.PrivateCV.description,
+          () => router.push("/feed")
+        );
+      }
     }
-  }
+  }, [validCV, canEditCv, showError, router, cv.id]);
 
   const showData = validCV ? "md:grid-cols-[70%_30%]" : "";
 

--- a/cv_next/providers/error-provider.tsx
+++ b/cv_next/providers/error-provider.tsx
@@ -14,7 +14,8 @@ import PopupWrapper from "@/components/ui/popupWrapper";
 interface ErrorContextType {
   errorMsg: string | null;
   errorDescription: string | null;
-  showError: (msg: string, desc: string, callback?: () => void) => void;
+  showError: ReturnType<typeof useCallback> &
+    ((msg: string, desc: string, callback?: () => void) => void);
   clearError: () => void;
   errorCallback: (() => void) | null;
 }
@@ -25,28 +26,38 @@ export const ErrorProvider = ({ children }: { children: ReactNode }) => {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [errorDescription, setErrorDescription] = useState<string | null>(null);
   const [errorCallback, setErrorCallback] = useState<(() => void) | null>(null);
+  const [clearState, triggerClear] = useState(false);
   const pathname = usePathname();
   const prevPathname = useRef<string | null>(null);
 
-  const showError = (msg: string, desc: string, callback?: () => void) => {
-    setErrorMsg(msg);
-    setErrorDescription(desc);
-    setErrorCallback(callback || null);
-  };
+  const showError = useCallback(
+    (msg: string, desc: string, callback?: () => void) => {
+      setErrorMsg(msg);
+      setErrorDescription(desc);
+      setErrorCallback(() => callback || null);
+    },
+    [setErrorMsg, setErrorDescription, setErrorCallback]
+  );
 
-  const clearError = useCallback(() => {
-    setErrorMsg(null);
-    setErrorDescription(null);
-    if (errorCallback) errorCallback();
-    setErrorCallback(null);
-  }, [errorCallback]);
+  useEffect(() => {
+    if (clearState) {
+      setErrorMsg(null);
+      setErrorDescription(null);
+      const currentCallback = errorCallback;
+      setErrorCallback(null);
+      triggerClear(false);
+      if (currentCallback) {
+        currentCallback();
+      }
+    }
+  }, [clearState, errorCallback, triggerClear]);
 
   useEffect(() => {
     if (prevPathname.current && prevPathname.current !== pathname && errorMsg) {
-      clearError();
+      triggerClear(true);
     }
     prevPathname.current = pathname;
-  }, [pathname, errorMsg, clearError]);
+  }, [pathname, errorMsg, triggerClear]);
 
   return (
     <ErrorContext.Provider
@@ -54,13 +65,13 @@ export const ErrorProvider = ({ children }: { children: ReactNode }) => {
         errorMsg,
         errorDescription,
         showError,
-        clearError,
+        clearError: () => triggerClear(true),
         errorCallback,
       }}
     >
       {children}
       {errorMsg && (
-        <PopupWrapper onClose={clearError}>
+        <PopupWrapper onClose={() => triggerClear(true)}>
           <div className="flex flex-col items-center justify-center rounded-md border-2 border-primary bg-destructive px-4 py-2 text-primary">
             <div className="text-xl font-bold">{errorMsg}</div>
             {errorDescription && (


### PR DESCRIPTION
## Description

A couple of fixes on the stateful behavior of the Error Provider, along with an automatic push to cv edit page for editors on a bad cv page.

Fixes #365 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A: when cv page with bad cv (triggering error message) reached, with edit permissions -> then on click triggers router change to /edit page.

**Test Configuration**:

- Firmware version:
- Hardware: Windows
- Toolchain:
- SDK:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
