### PR TITLE
371 bug   private cvs are seen as broken images instead of lock

### DIFF
--- a/cv_next/app/api/cvs/fetchPreviews/route.ts
+++ b/cv_next/app/api/cvs/fetchPreviews/route.ts
@@ -12,8 +12,9 @@ import { validateGoogleViewOnlyUrl } from "@/helpers/cvLinkRegexHelper";
 const blobDataMap = new Map<string, Blob>();
 
 /**
- *
- * @param req
+ * The POST request handler for the revalidatePreview endpoint.
+ * @param {NextRequest} req The request object that was sent to the server.
+ * @returns {Promise<NextResponse>} The response object with the relevant data or error message.
  */
 export async function POST(req: NextRequest) {
   const data = await req.json();

--- a/cv_next/app/api/cvs/fetchPreviews/route.ts
+++ b/cv_next/app/api/cvs/fetchPreviews/route.ts
@@ -11,6 +11,10 @@ import { validateGoogleViewOnlyUrl } from "@/helpers/cvLinkRegexHelper";
 
 const blobDataMap = new Map<string, Blob>();
 
+/**
+ *
+ * @param req
+ */
 export async function POST(req: NextRequest) {
   const data = await req.json();
   if (data.pathname.endsWith("revalidatePreview")) {
@@ -23,7 +27,9 @@ export async function POST(req: NextRequest) {
  * Revalidate the image a given CV in supabase
  * If the hash of the CV that was saved in the map is similar to the one that just got fetched
  * nothing is done. If something changed, the image is uploaded to supabase again
+ * @param data
  * @param {string} cvLink - The cv link to validate
+ * @param data.cvLink
  * @returns {Promise<NextResponse>} - The response with the public url of the image, or the relevant message
  */
 async function revalidatePreviewHandler(data: {
@@ -43,7 +49,7 @@ async function revalidatePreviewHandler(data: {
     redirect: "manual",
   });
 
-  if (fetchDocsResponse.status === 302) {
+  if (fetchDocsResponse.status === 302 || fetchDocsResponse.status === 404) {
     logger.error("Redirected when asked for usercontent, probably private");
     return NextResponse.json({ message: "CV is private" }, { status: 500 });
   }


### PR DESCRIPTION
## Description

Fixes the problem where CVs that were set to private were seen as broken images

Fixes #371 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Using different CVs and accounts (for both Google Docs and Google Drive, as each handles things differently in Google's backend).

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
