### PR TITLE
UPDATED: cvs now use private buckets with signed previews

### DIFF
--- a/cv_next/.eslintrc.json
+++ b/cv_next/.eslintrc.json
@@ -58,18 +58,21 @@
             "format": ["PascalCase", "camelCase"] //camelCase: functions (mainly hooks)
           },
           {
-            "selector": "variable",
-            "format": ["camelCase", "PascalCase"]
+            "selector": ["variable", "class"],
+            "format": null,
+            "filter": {
+              "regex": "^[A-Z][A-Za-z0-9]*(?:_[A-Z][A-Za-z0-9]*)*$",
+              "match": true
+            }
           },
           {
             "selector": ["variable"],
             "modifiers": ["const"],
-            "format": ["camelCase", "PascalCase", "UPPER_CASE"] //PascalCase: relevant for e.g. React components, Context
+            "format": ["camelCase", "PascalCase", "UPPER_CASE"]
           },
           {
             "selector": "function",
-            "format": ["PascalCase", "camelCase"],
-            "filter": { "regex": "^[A-Z]", "match": true }
+            "format": ["PascalCase", "camelCase"]
           },
           {
             "selector": ["variable", "parameter", "function", "method"],
@@ -78,7 +81,7 @@
           },
           {
             "selector": ["objectLiteralProperty"],
-            "format": ["snake_case", "camelCase"],
+            "format": ["snake_case", "camelCase", "PascalCase"],
             "leadingUnderscore": "allow"
           },
           {

--- a/cv_next/app/api/cvs/fetchPreviews/route.ts
+++ b/cv_next/app/api/cvs/fetchPreviews/route.ts
@@ -8,6 +8,7 @@ import { compareHashes } from "@/helpers/blobHelper";
 import logger from "@/server/base/logger";
 import { Storage } from "@/lib/supabase-definitions";
 import { validateGoogleViewOnlyUrl } from "@/helpers/cvLinkRegexHelper";
+import { getCVSignedPreview } from "@/server/api/cvs";
 
 const blobDataMap = new Map<string, Blob>();
 
@@ -62,14 +63,11 @@ async function revalidatePreviewHandler(data: {
 
   if (isSimilar) {
     logger.debug("Files were similar");
-    const { data: previewUrl, error } =
-      await SupabaseHelper.getSupabaseInstance()
-        .storage.from(Storage.cvs)
-        .createSignedUrl(fileName, 100);
-    const signedUrl = previewUrl?.signedUrl;
-
-    if (!error && previewUrl.signedUrl) return NextResponse.json({ signedUrl });
-    logger.error(error, "Failed to get signed URL");
+    const signedUrlResp = await getCVSignedPreview(fileName);
+    if (signedUrlResp.ok) {
+      return NextResponse.json({ signedUrl: signedUrlResp.val });
+    }
+    logger.error(signedUrlResp.errors.err, "Failed to get signed URL");
   }
 
   blobDataMap.delete(docsID || "");
@@ -98,14 +96,11 @@ async function revalidatePreviewHandler(data: {
     return NextResponse.json({ message: "RLS error" });
   } else {
     logger.debug(uploadedData, "File uploaded successfully:");
-    const { data: previewUrl, error } =
-      await SupabaseHelper.getSupabaseInstance()
-        .storage.from(Storage.cvs)
-        .createSignedUrl(fileName, 100);
-    const signedUrl = previewUrl?.signedUrl;
-
-    if (!error && previewUrl.signedUrl) return NextResponse.json({ signedUrl });
-    logger.error(error, "Failed to get signed URL after upload");
+    const signedUrlResp = await getCVSignedPreview(fileName);
+    if (signedUrlResp.ok) {
+      return NextResponse.json({ signedUrl: signedUrlResp.val });
+    }
+    logger.error(signedUrlResp.errors.err, "Failed to get signed URL");
   }
   return NextResponse.json(
     { error: "Failed to revalidate preview" },

--- a/cv_next/app/feed/components/CV/CVItem.tsx
+++ b/cv_next/app/feed/components/CV/CVItem.tsx
@@ -47,8 +47,8 @@ export default function CVItem({ cv }: CVCardProps) {
         if (data?.error == "CV_IS_PRIVATE") {
           setRealURL(access_denied.src);
           return;
-        } else if (data?.publicUrl) {
-          setRealURL(data.publicUrl);
+        } else if (data?.signedUrl) {
+          setRealURL(data.signedUrl);
         }
       };
 

--- a/cv_next/lib/definitions.ts
+++ b/cv_next/lib/definitions.ts
@@ -11,6 +11,7 @@ export default class Definitions {
   public static readonly MAX_OPERATIONS_REFILL_PER_SECOND = 2;
   public static readonly CVS_REVALIDATE_TIME_IN_SECONDS = 0;
   public static readonly FETCH_WAIT_TIME = 120;
+  public static readonly CV_PREVIEW_EXPIRATION_TIME = 60 * 30;
   public static readonly MAX_CHAR_NAME = 70;
   public static readonly MIN_CHAR_NAME = 1;
   public static readonly MAX_COMMENT_SIZE = 750;

--- a/cv_next/server/api/cvs.ts
+++ b/cv_next/server/api/cvs.ts
@@ -273,7 +273,7 @@ export async function getCVSignedPreview(
 ): Promise<Result<string, string>> {
   const { data: previewUrl, error } = await SupabaseHelper.getSupabaseInstance()
     .storage.from(Storage.cvs)
-    .createSignedUrl(fileName, 100);
+    .createSignedUrl(fileName, Definitions.CV_PREVIEW_EXPIRATION_TIME);
   const signedUrl = previewUrl?.signedUrl;
 
   if (!error && signedUrl) return Ok(signedUrl);

--- a/cv_next/server/api/cvs.ts
+++ b/cv_next/server/api/cvs.ts
@@ -1,7 +1,12 @@
 import "server-only";
 
 import { PostgrestError } from "@supabase/supabase-js";
-import { Tables, CvKeys, ProfileKeys } from "@/lib/supabase-definitions";
+import {
+  Tables,
+  CvKeys,
+  ProfileKeys,
+  Storage,
+} from "@/lib/supabase-definitions";
 import { filterValues } from "@/types/models/filters";
 import Definitions from "@/lib/definitions";
 import logger from "@/server/base/logger";
@@ -256,4 +261,23 @@ export async function markCVAsDeleted(
       err: err as Error,
     });
   }
+}
+
+/**
+ * The function will get the signed preview URL of a given CV.
+ * @param {string} fileName Which preview to get
+ * @returns {Promise<Result<string, string>>} The signed URL or an error message.
+ */
+export async function getCVSignedPreview(
+  fileName: string
+): Promise<Result<string, string>> {
+  const { data: previewUrl, error } = await SupabaseHelper.getSupabaseInstance()
+    .storage.from(Storage.cvs)
+    .createSignedUrl(fileName, 100);
+  const signedUrl = previewUrl?.signedUrl;
+
+  if (!error && signedUrl) return Ok(signedUrl);
+  return Err(getCVSignedPreview.name, {
+    err: error as Error,
+  });
 }


### PR DESCRIPTION
## Description

This PR changes the way previews are saved from public buckets that are viewable for everyone to a private bucket that requires authentication.

Fixes #128 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Without getting a valid URL from the supabase instance, the pictures couldn't be fetched.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
